### PR TITLE
Bump spark version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ CMD ["/opt/spark-connect-proxy/spark-connect-proxy"]
 
 FROM ubuntu:noble AS spark-cache
 
-ARG SPARK_VERSION=4.0.0
+ARG SPARK_VERSION=4.0.1
 
 RUN apt-get update && \
     apt-get install -y wget
@@ -59,7 +59,7 @@ RUN wget -q https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_
 
 FROM base
 
-ARG SPARK_VERSION=4.0.0
+ARG SPARK_VERSION=4.0.1
 
 COPY --from=spark-cache /opt/spark-${SPARK_VERSION}-bin-hadoop3 /opt/spark
 

--- a/dev/Dockerfile-server
+++ b/dev/Dockerfile-server
@@ -1,7 +1,7 @@
 FROM rust:1.88 AS rust-builder
 
 ARG TARGETPLATFORM
-ARG SPARK_VERSION=4.0.0
+ARG SPARK_VERSION=4.0.1
 
 RUN wget -q https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz && \
     tar -xf spark-${SPARK_VERSION}-bin-hadoop3.tgz -C /opt && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   server:
     build:


### PR DESCRIPTION
- Bump spark to `4.0.1`, the tarball download URL doesn't exist for `4.0.0` anymore
- Get rid of `version` line in compose spec to get rid of warning about the attribute being ignored